### PR TITLE
[Fix] Add zip_safe option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,8 @@ classifiers =
     Programming Language :: Python :: 3.6
 
 [options]
+# Unpack your project to .egg or no?
+zip_safe = False
 # You can just specify the packages manually here if your project is
 # simple. Or you can use find.
 packages = find:


### PR DESCRIPTION
### 1. Summary

I add `zip_safe` parameter. [**pyroma**](https://pypi.python.org/pypi/pyroma/) requires, that `setup.cfg` contains it.

### 2. Steps to reproduce

I clone `update/distribute` branch of your repository → I run pyroma in repository folder.

### 3. Behavior before pull request

```c++
D:\sampleproject>pyroma .
------------------------------
Checking .
Found sample
------------------------------
You are using Setuptools or Distribute but do not specify if this package is zip_safe or not. You should specify it, as it defaults to True, which you probably do not want.
------------------------------
Final rating: 9/10
Cottage Cheese
------------------------------

```

### 4. Behavior after pull request

```c++
D:\sampleproject>pyroma .
------------------------------
Checking .
Found pyfancy
------------------------------
Final rating: 10/10
Your cheese is so fresh most people think it's a cream: Mascarpone
------------------------------
```

### 5. Testing environment

+ Windows 10 Enterprise LTSB 64-bit EN,
+ Python 3.6.4,
+ pyroma 2.3.

Thanks.